### PR TITLE
- Added a way to programmatically open the find elements dialog

### DIFF
--- a/src/Core/SuperMemoAssistant.Core/NativeDataCfg.json
+++ b/src/Core/SuperMemoAssistant.Core/NativeDataCfg.json
@@ -150,6 +150,10 @@
       "Queue_GetItem": { // TQueue::GetItem
         "Pattern": "E8 ? ? ? ? 89 45 AB",
         "Offset": 1
+      },
+      "TSMMain_FindElements": {
+        "Pattern": "E8 ? ? ? ? EB 11 8A 4D FA",
+        "Offset":  1
       }
     },
     "NativeDataPatterns": {},
@@ -314,6 +318,10 @@
       "Queue_GetItem": { // TQueue::GetItem
         "Pattern": "E8 ? ? ? ? 89 45 AB",
         "Offset": 1
+      },
+      "TSMMain_FindElements": {
+        "Pattern": "E8 ? ? ? ? EB 11 8A 4D FA",
+        "Offset":  1
       }
     },
     "NativeDataPatterns": {},
@@ -478,6 +486,10 @@
       "Queue_GetItem": { // TQueue::GetItem
         "Pattern": "E8 ? ? ? ? 89 45 AB",
         "Offset": 1
+      },
+      "TSMMain_FindElements": {
+        "Pattern": "E8 ? ? ? ? EB 11 8A 4D FA",
+        "Offset":  1
       }
     },
     "NativeDataPatterns": {},
@@ -647,7 +659,11 @@
       },
       "Queue_GetItem": { // TQueue::GetItem
         "Pattern": "E8 ? ? ? ? 89 45 AB",
-        "Offset": 1 
+        "Offset": 1
+      },
+      "TSMMain_FindElements": {
+        "Pattern": "E8 ? ? ? ? EB 11 8A 4D FA",
+        "Offset":  1
       }
     },
     "NativeDataPatterns": {},

--- a/src/Core/SuperMemoAssistant.Core/SuperMemo/Natives/SMNatives.TSMMain.cs
+++ b/src/Core/SuperMemoAssistant.Core/SuperMemo/Natives/SMNatives.TSMMain.cs
@@ -81,6 +81,24 @@ namespace SuperMemoAssistant.SuperMemo.Natives
         }
       }
 
+      // TODO:
+      // I copied these parameters from the IDR dissasembly of the TSMMain.MIFindElementsClick
+      // Not entirely sure what they mean
+      // param y I believe represents the search target (registry?)
+      public bool FindElements(char x, char y, char z)
+      {
+        try
+        {
+          NativeMethod.TSMMain_FindElements.ExecuteOnMainThread(x, y, z);
+          return true;
+        }
+        catch (Exception ex)
+        {
+          LogTo.Error(ex, "Native method call threw an exception.");
+          return false;
+        }
+      }
+
       #endregion
     }
   }

--- a/src/Core/SuperMemoAssistant.Core/SuperMemo/SuperMemo17/UI/ElementWdw.cs
+++ b/src/Core/SuperMemoAssistant.Core/SuperMemo/SuperMemo17/UI/ElementWdw.cs
@@ -147,6 +147,24 @@ namespace SuperMemoAssistant.SuperMemo.SuperMemo17.UI
       return success && CurrentConceptId == conceptId;
     }
 
+    public bool OpenFindElementsDialog()
+    {
+      try
+      {
+        return Core.Natives.SMMain.FindElements((char)3, (char)1, (char)0);
+      }
+      catch (Win32Exception ex)
+      {
+        LogTo.Warning(ex, "Failed to read SMMainWdwPtr");
+        return false;
+      }
+      catch (Exception ex)
+      {
+        LogTo.Error(ex, "SM internal method call threw an exception.");
+        return false;
+      }
+    }
+
     public bool GoToElement(int elementId)
     {
       try

--- a/src/Core/SuperMemoAssistant.Hooks.Common/SuperMemo/NativeMethod.cs
+++ b/src/Core/SuperMemoAssistant.Hooks.Common/SuperMemo/NativeMethod.cs
@@ -64,6 +64,7 @@ namespace SuperMemoAssistant.SuperMemo
     TCompData_SetTextRegMember,
     TCompData_GetImageRegMember,
     TCompData_SetImageRegMember,
+    TSMMain_FindElements,
     TSMMain_SelectDefaultConcept,
     TRegistry_AddMember,
     TRegistry_ImportFile,


### PR DESCRIPTION
NativeMethod.TSMMain_FindElements.ExecuteOnMainThread(x, y, z);

The underlying search method is a generic function that SM uses to search its various registries.
I am not entirely sure what the parameters represent yet. Though I believe the y parameter represents the search target (registry?)
The parameters for this method added to the ElementWdw are copied from the IDR disassembly for the TSMMain.MIFindElementsClick function.

Let me know if you want me to investigate further / add / change anything etc.